### PR TITLE
SOC value missing from the API on systems without battery

### DIFF
--- a/boilr/app.py
+++ b/boilr/app.py
@@ -142,8 +142,12 @@ def run():
             logger.error("Error parsing JSON response (powerflow inverter): %s", e_general)
             return False
         else:
-            powerflow_soc = powerflow_inverters['SOC'] # state of charge
-            logger.debug("SOC: %s %%", round(powerflow_soc, 1))
+             if not powerflow_site['P_Akku'] is None:
+                powerflow_soc = powerflow_inverters['SOC'] # state of charge
+                logger.debug("SOC: %s %%", round(powerflow_soc, 1))
+            else:
+                powerflow_soc = 100
+                logger.debug("SOC: Battery not active, ignoring SOC")
 
         ## set gpio mode
         if not rpi_gpio.gpio_mode(config.RpiConfig.rpi_channel_relay_out, "out"):

--- a/boilr/app.py
+++ b/boilr/app.py
@@ -142,7 +142,7 @@ def run():
             logger.error("Error parsing JSON response (powerflow inverter): %s", e_general)
             return False
         else:
-             if not powerflow_site['P_Akku'] is None:
+            if not powerflow_site['P_Akku'] is None:
                 powerflow_soc = powerflow_inverters['SOC'] # state of charge
                 logger.debug("SOC: %s %%", round(powerflow_soc, 1))
             else:


### PR DESCRIPTION
I have a PV system with a Fronius inverter without battery. When querying the API of my device, there is no "SOC" value, which the script relies on. My quick fix was to set the SOC to 100 if "P_Akku" is null.